### PR TITLE
Fix wishlist auth and get admin credentials

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -5,4 +5,18 @@ const api = axios.create({
 	withCredentials: true,
 });
 
+// Attach JWT from localStorage on every request to avoid race conditions on app load
+api.interceptors.request.use((config) => {
+    try {
+        const token = localStorage.getItem('kh_token');
+        if (token) {
+            config.headers = config.headers || {};
+            if (!config.headers['Authorization']) {
+                config.headers['Authorization'] = `Bearer ${token}`;
+            }
+        }
+    } catch {}
+    return config;
+});
+
 export default api;


### PR DESCRIPTION
Add Axios request interceptor to attach JWT from localStorage, resolving 401 Unauthorized errors for authenticated API calls.

The `401 Unauthorized` error on the wishlist API call indicated that the authentication token was not being consistently sent with requests. This interceptor ensures the JWT is always included in the `Authorization` header, preventing such authentication failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e9d08a8-1ee8-4844-b03e-f50689ace1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e9d08a8-1ee8-4844-b03e-f50689ace1c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

